### PR TITLE
updated to maptime URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,8 @@ window.onload = function() {
     go(cur);
 };
 </script></head><body>
-<div><em>OSM</em> 101 <a href="http://sta.mn/y9d">sta.mn/y9d</a></div>
-<div>Housekeeping!<br>You can follow along here: <a href="http://sta.mn/y9d">sta.mn/y9d</a>. Links are in blue boxes, <em>green</em> is just emphasis. Change slides w/ arrow keys. You can comment and edit on <a href="https://github.com/maptime/osm-101/">github!</a></div>
+<div><em>OSM</em> 101 <a href="http://maptime.io/osm-101/">maptime.io/osm-101</a></div>
+<div>Housekeeping!<br>You can follow along here: <a href="http://maptime.io/osm-101/">maptime.io/osm-101</a>. Links are in blue boxes, <em>green</em> is just emphasis. Change slides w/ arrow keys. You can comment and edit on <a href="https://github.com/maptime/osm-101/">github!</a></div>
 <div style="color: black"><img src="sf.png">What is OpenStreetMap?</div>
 <div style="color: black"><img src="sf.png">OpenStreetMap is the <a href="https://www.google.com/search?q=%22wikipedia+of+maps%22">"Wikipedia of maps"</a></div>
 <div style="color: black"><img src="sf.png">Anyone (like YOU!) can edit OSM</div>


### PR DESCRIPTION
Not positive If this changes the URL in all the right places-- I may have missed some. I only saw the legacy Stamen URL on the first two slides. 

(It wasn't technically broken, the Stamen URL redirects to the Maptime one, but i figured the Maptime URL was more "on brand" :wink: )
